### PR TITLE
Feature/add multiple hosts configuration

### DIFF
--- a/src/InsiderAbstractFeatures.php
+++ b/src/InsiderAbstractFeatures.php
@@ -39,9 +39,9 @@ class InsiderAbstractFeatures
      * @throws InsiderApiException
      * @throws InsiderApiClientException
      */
-    public function sendRequest(RequestInterface $request): ResponseInterface
+    public function sendRequest(RequestInterface $request, InsiderApiHostType $hostType): ResponseInterface
     {
-        $host = $this->configuration->getHost();
+        $host = $this->configuration->getHosts()[$hostType->getValue()];
 
         // Forge URI
         $URI = $request->getUri();

--- a/src/InsiderAbstractFeatures.php
+++ b/src/InsiderAbstractFeatures.php
@@ -41,7 +41,12 @@ class InsiderAbstractFeatures
      */
     public function sendRequest(RequestInterface $request, InsiderApiHostType $hostType): ResponseInterface
     {
-        $host = $this->configuration->getHosts()[$hostType->getValue()];
+        // Retrieve host
+        $host = $this->configuration->getHosts()[$hostType->getValue()] ?? null;
+
+        if($host === null) {
+            throw new InsiderApiClientException("Missing host in configuration for type : $hostType");
+        }
 
         // Forge URI
         $URI = $request->getUri();

--- a/src/InsiderApiConfiguration.php
+++ b/src/InsiderApiConfiguration.php
@@ -16,25 +16,21 @@ use Psr\Http\Message\UriFactoryInterface;
  * @method RequestFactoryInterface|null getRequestFactory()
  * @method StreamFactoryInterface|null getStreamFactory()
  * @method UriFactoryInterface|null getUriFactory()
- * @method InsiderApiHost|null getHost()
+ * @method InsiderApiHost[] getHosts()
  */
 class InsiderApiConfiguration
 {
-    private InsiderApiHost $host;
+    /** @var InsiderApiHost[]  */
+    private array $hosts = [];
     protected ClientInterface $httpClient;
     protected RequestFactoryInterface $requestFactory;
     protected StreamFactoryInterface $streamFactory;
     protected UriFactoryInterface $uriFactory;
     protected bool $built = false;
 
-    private function __construct(InsiderApiHost $host)
+    public static function builder(): self
     {
-        $this->host = $host;
-    }
-
-    public static function builder(InsiderApiHost $host): self
-    {
-        return new self($host);
+        return new self();
     }
 
     public function build(): self
@@ -68,9 +64,12 @@ class InsiderApiConfiguration
         return call_user_func_array(array($this, $methodName), $arguments);
     }
 
-    protected function _getHost(): ?InsiderApiHost
+    /**
+     * @return InsiderApiHost[]
+     */
+    protected function _getHosts(): array
     {
-        return $this->host;
+        return $this->hosts;
     }
 
     protected function _getHttpClient(): ?ClientInterface
@@ -93,10 +92,17 @@ class InsiderApiConfiguration
         return $this->uriFactory;
     }
 
-    public function withHost(InsiderApiHost $host): self
+    public function withUnificationHost(InsiderApiHost $unificationHost): self
     {
         $return = clone $this;
-        $return->host = $host;
+        $return->hosts[InsiderApiHostType::UNIFICATION] = $unificationHost;
+        return $return;
+    }
+
+    public function withMobileHost(InsiderApiHost $mobileHost): self
+    {
+        $return = clone $this;
+        $return->hosts[InsiderApiHostType::MOBILE] = $mobileHost;
         return $return;
     }
 

--- a/src/InsiderApiHostType.php
+++ b/src/InsiderApiHostType.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Chargemap\InsiderSdk;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * @method static self UNIFICATION()
+ * @method static self MOBILE()
+ */
+class InsiderApiHostType extends Enum
+{
+    public const UNIFICATION = 'UNIFICATION';
+    public const MOBILE = 'MOBILE';
+}

--- a/src/InsiderApiRequest.php
+++ b/src/InsiderApiRequest.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Chargemap\InsiderSdk;
+
+interface InsiderApiRequest
+{
+    public function getHostType(): InsiderApiHostType;
+}

--- a/src/Users/UpdateIdentifiers/UpdateUserIdentifiersRequest.php
+++ b/src/Users/UpdateIdentifiers/UpdateUserIdentifiersRequest.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Chargemap\InsiderSdk\Users\UpdateIdentifiers;
 
+use Chargemap\InsiderSdk\InsiderApiHostType;
+use Chargemap\InsiderSdk\InsiderApiRequest;
 use Chargemap\InsiderSdk\Users\UserIdentifiers;
 use JsonSerializable;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 
-class UpdateUserIdentifiersRequest implements JsonSerializable
+class UpdateUserIdentifiersRequest implements InsiderApiRequest, JsonSerializable
 {
     private UserIdentifiers $oldIdentifiers;
     private UserIdentifiers $newIdentifiers;
@@ -44,5 +46,10 @@ class UpdateUserIdentifiersRequest implements JsonSerializable
             'old_identifier' => $this->oldIdentifiers,
             'new_identifier' => $this->newIdentifiers,
         ];
+    }
+
+    public function getHostType(): InsiderApiHostType
+    {
+        return InsiderApiHostType::UNIFICATION();
     }
 }

--- a/src/Users/UpdateIdentifiers/UpdateUserIdentifiersService.php
+++ b/src/Users/UpdateIdentifiers/UpdateUserIdentifiersService.php
@@ -17,6 +17,6 @@ class UpdateUserIdentifiersService extends InsiderAbstractFeatures
     public function handle(UpdateUserIdentifiersRequest $request): void
     {
         $requestInterface = $request->getRequestInterface($this->requestFactory, $this->streamFactory);
-        $this->sendRequest($requestInterface);
+        $this->sendRequest($requestInterface, $request->getHostType());
     }
 }

--- a/src/Users/Upsert/UpsertUsersDataRequest.php
+++ b/src/Users/Upsert/UpsertUsersDataRequest.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Chargemap\InsiderSdk\Users\Upsert;
 
+use Chargemap\InsiderSdk\InsiderApiHostType;
+use Chargemap\InsiderSdk\InsiderApiRequest;
 use Chargemap\InsiderSdk\Users\User;
 use JsonSerializable;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 
-class UpsertUsersDataRequest implements JsonSerializable
+class UpsertUsersDataRequest implements InsiderApiRequest, JsonSerializable
 {
     /** @var User[] */
     private array $users = [];
@@ -50,5 +52,10 @@ class UpsertUsersDataRequest implements JsonSerializable
         return [
             'users' => $this->users
         ];
+    }
+
+    public function getHostType(): InsiderApiHostType
+    {
+        return InsiderApiHostType::UNIFICATION();
     }
 }

--- a/src/Users/Upsert/UpsertUsersDataService.php
+++ b/src/Users/Upsert/UpsertUsersDataService.php
@@ -17,7 +17,7 @@ class UpsertUsersDataService extends InsiderAbstractFeatures
     public function handle(UpsertUsersDataRequest $request): UpsertUsersDataResponse
     {
         $requestInterface = $request->getRequestInterface($this->requestFactory, $this->streamFactory);
-        $responseInterface = $this->sendRequest($requestInterface);
+        $responseInterface = $this->sendRequest($requestInterface, $request->getHostType());
         $json = self::asJson($responseInterface);
         return UpsertUsersDataResponseFactory::fromJson($json);
     }

--- a/tests/InsiderAbstractFeaturesTest.php
+++ b/tests/InsiderAbstractFeaturesTest.php
@@ -56,6 +56,28 @@ class InsiderAbstractFeaturesTest extends TestCase
         $this->abstractFeatures = new InsiderAbstractFeatures($this->configuration);
     }
 
+    public function sendRequestThrowsIfHostIsMissingProvider(): iterable
+    {
+        foreach(InsiderApiHostType::values() as $case) {
+            yield [$case];
+        }
+    }
+
+    /**
+     * @dataProvider sendRequestThrowsIfHostIsMissingProvider
+     * @throws InsiderApiClientException
+     * @throws InsiderApiException
+     */
+    public function testSendRequestThrowsIfHostIsMissing(InsiderApiHostType $hostType): void
+    {
+        $configuration = InsiderApiConfiguration::builder();
+        $abstractFeatures = new InsiderAbstractFeatures($configuration);
+        $request = Psr17FactoryDiscovery::findRequestFactory()->createRequest('POST', '');
+
+        $abstractFeatures->sendRequest($request, $hostType);
+        $this->expectExceptionObject(new InsiderApiClientException("Missing host in configuration for type : $hostType"));
+    }
+
     public function sendRequestForgesCorrectUnificationUriProvider(): iterable
     {
         yield 'correct by default' => [

--- a/tests/InsiderAbstractFeaturesTest.php
+++ b/tests/InsiderAbstractFeaturesTest.php
@@ -61,7 +61,7 @@ class InsiderAbstractFeaturesTest extends TestCase
     public function sendRequestThrowsIfHostIsMissingProvider(): iterable
     {
         foreach(InsiderApiHostType::values() as $case) {
-            yield [$case, InsiderApiClient::class, "Missing host in configuration for type : $case"];
+            yield [$case, InsiderApiClientException::class, "Missing host in configuration for type : $case"];
         }
     }
 

--- a/tests/InsiderAbstractFeaturesTest.php
+++ b/tests/InsiderAbstractFeaturesTest.php
@@ -70,7 +70,7 @@ class InsiderAbstractFeaturesTest extends TestCase
      */
     public function testSendRequestThrowsIfHostIsMissing(InsiderApiHostType $hostType): void
     {
-        $configuration = InsiderApiConfiguration::builder();
+        $configuration = InsiderApiConfiguration::builder()->build();
         $abstractFeatures = new InsiderAbstractFeatures($configuration);
         $request = Psr17FactoryDiscovery::findRequestFactory()->createRequest('POST', '');
 

--- a/tests/InsiderAbstractFeaturesTest.php
+++ b/tests/InsiderAbstractFeaturesTest.php
@@ -61,30 +61,23 @@ class InsiderAbstractFeaturesTest extends TestCase
     public function sendRequestThrowsIfHostIsMissingProvider(): iterable
     {
         foreach(InsiderApiHostType::values() as $case) {
-            yield [$case, InsiderApiClientException::class, "Missing host in configuration for type : $case"];
+            yield [$case];
         }
     }
 
     /**
      * @dataProvider sendRequestThrowsIfHostIsMissingProvider
+     * @throws InsiderApiClientException
+     * @throws InsiderApiException
      */
-    public function testSendRequestThrowsIfHostIsMissing(InsiderApiHostType $hostType, string $exceptionType, $exceptionMessage): void
+    public function testSendRequestThrowsIfHostIsMissing(InsiderApiHostType $hostType): void
     {
         $configuration = InsiderApiConfiguration::builder()->build();
         $abstractFeatures = new InsiderAbstractFeatures($configuration);
         $request = Psr17FactoryDiscovery::findRequestFactory()->createRequest('POST', '');
 
-        $exception = null;
-
-        try {
-            $abstractFeatures->sendRequest($request, $hostType);
-        } catch(Exception $e) {
-            $exception = $e;
-        }
-
-        $this->assertTrue($exception !== null);
-        $this->assertEquals($exceptionType, get_class($exception));
-        $this->assertEquals($exceptionMessage, $exceptionMessage);
+        $this->expectExceptionObject(new InsiderApiClientException("Missing host in configuration for type : $hostType"));
+        $abstractFeatures->sendRequest($request, $hostType);
     }
 
     public function sendRequestForgesCorrectUnificationUriProvider(): iterable


### PR DESCRIPTION
Préparation du SDK pour la feature des push notifications ; la structure de l'API d'Insider dispose d'hôtes différents suivant les requêtes à effectuer. 

Vu avec @ChargemapMikhail : on aura donc une variable d'environnement pour chaque host :
- INSIDER_UNIFICATION_HOST=https://unification.useinsider.com
- INSIDER_MOBILE_HOST=https://mobile.useinsider.com